### PR TITLE
Test updates

### DIFF
--- a/test-server/server.js
+++ b/test-server/server.js
@@ -22,9 +22,9 @@ var JS_SOURCE_PATH = '../test/',
     APP_SOURCE_PATH = '../RNFetchBlobTest/'
 
 // watch test app source
-watch(JS_SOURCE_PATH, APP_SOURCE_PATH, {ignored: /\.git\//})
+watch(JS_SOURCE_PATH, APP_SOURCE_PATH, {ignored: /\.git\/|_tmp___/})
 // watch lib js source
-watch(LIB_SOURCE_PATH, NODE_MODULE_MODULE_PATH, {ignored: /\.git\/|\.\.\/src\/(android|ios)\//})
+watch(LIB_SOURCE_PATH, NODE_MODULE_MODULE_PATH, {ignored: /\.git\/|_tmp___|\.\.\/src\/(android|ios)\//})
 
 // https
 var server = https.createServer({

--- a/test-server/server.js
+++ b/test-server/server.js
@@ -22,9 +22,9 @@ var JS_SOURCE_PATH = '../test/',
     APP_SOURCE_PATH = '../RNFetchBlobTest/'
 
 // watch test app source
-watch(JS_SOURCE_PATH, APP_SOURCE_PATH)
+watch(JS_SOURCE_PATH, APP_SOURCE_PATH, {ignored: /\.git\//})
 // watch lib js source
-watch(LIB_SOURCE_PATH, NODE_MODULE_MODULE_PATH, {ignored: /\.\.\/src\/(android|ios)\//})
+watch(LIB_SOURCE_PATH, NODE_MODULE_MODULE_PATH, {ignored: /\.git\/|\.\.\/src\/(android|ios)\//})
 
 // https
 var server = https.createServer({
@@ -293,22 +293,25 @@ function watch(source, dest, ignore) {
   chokidar
     .watch(source, ignore)
     .on('add', function(path) {
+      path = path.replace(/\\/g, '/');
       console.log(chalk.magenta('file created'), path)
       var targetPath = String(path).replace(source, dest)
       mkdirp(dirname(targetPath), function (err) {
-      if (err) return cb(err)
+        if (err) return cb(err)
         fs.writeFileSync(targetPath, fs.readFileSync(path))
       })
     })
     .on('change', function(path) {
+      path = path.replace(/\\/g, '/');
       console.log(chalk.green('file changed'), path)
       var targetPath = String(path).replace(source, dest)
       mkdirp(dirname(targetPath), function (err) {
-      if (err) return cb(err)
+        if (err) return cb(err)
         fs.writeFileSync(targetPath, fs.readFileSync(path))
       })
     })
     .on('unlink', function(path) {
+      path = path.replace(/\\/g, '/');
       console.log(chalk.red('file removed'), path)
       var targetPath = String(path).replace(source, dest)
       mkdirp(dirname(targetPath), function (err) {

--- a/test-server/server.js
+++ b/test-server/server.js
@@ -72,7 +72,7 @@ app.get('/10s-download', (req,res) => {
   var data = ''
   for(var i =0;i<1024000;i++)
     data += '1'
-  res.set('Contet-Length', 1024000*10)
+  res.set('Content-Length', 1024000*10)
   var it = setInterval(() => {
     res.write(data)
     count++

--- a/test/react-native-testkit/components/reporter.js
+++ b/test/react-native-testkit/components/reporter.js
@@ -77,6 +77,8 @@ export default class Reporter extends Component {
           </View>
         </View>
         <ListView
+          // empty section headers: https://github.com/FaridSafi/react-native-gifted-listview/issues/39
+          enableEmptySections={true}
           style={[styles.container]}
           dataSource={this.ds}
           renderRow={this.renderTest.bind(this)}

--- a/test/test-blob.js
+++ b/test/test-blob.js
@@ -236,7 +236,7 @@ describe('#89 Blob.slice test', (report, done) => {
     Promise.all(testData.map(assert)).then(done)
   }
 
-  function assert(d):Promise {
+  function assert(d) {
     let content = d[0]
     let assertions = d[1]
     console.log('create blob content = ', content)

--- a/test/test-fetch.js
+++ b/test/test-fetch.js
@@ -2,150 +2,152 @@ import RNTest from './react-native-testkit/'
 import React from 'react'
 import RNFetchBlob from 'react-native-fetch-blob'
 
-import {
-  StyleSheet,
-  Text,
-  View,
-  ScrollView,
-  Platform,
-  Dimensions,
-  Image,
-} from 'react-native';
+import {Dimensions, Image, Platform, ScrollView, StyleSheet, Text, View,} from 'react-native';
 
 window.Blob = RNFetchBlob.polyfill.Blob
 window.File = RNFetchBlob.polyfill.File
 window.fetch = new RNFetchBlob.polyfill.Fetch({
-  auto : true,
-  binaryContentTypes : ['image/', 'video/', 'audio/']
+  auto: true,
+  binaryContentTypes: ['image/', 'video/', 'audio/']
 }).build()
 
 const fs = RNFetchBlob.fs
-const { Assert, Comparer, Info, prop } = RNTest
+const {Assert, Comparer, Info, prop} = RNTest
 const describe = RNTest.config({
-  group : 'Fetch polyfill',
-  run : true,
-  expand : true,
-  timeout : 10000,
+  group: 'Fetch polyfill',
+  run: true,
+  expand: true,
+  timeout: 10000,
 })
-const { TEST_SERVER_URL, TEST_SERVER_URL_SSL, FILENAME, DROPBOX_TOKEN, styles } = prop()
+const {TEST_SERVER_URL, TEST_SERVER_URL_SSL, FILENAME, DROPBOX_TOKEN, styles} = prop()
 const dirs = RNFetchBlob.fs.dirs
 
 let prefix = ((Platform.OS === 'android') ? 'file://' : '')
 
 describe('GET request test : unicode text -> any', (report, done) => {
-
   function get(fn1, fn2) {
-    return fetch(`${TEST_SERVER_URL}/unicode`, { method : 'GET'})
-    .then((res) => fn1(res))
-    .then((data) => fn2(data))
+    return fetch(`${TEST_SERVER_URL}/unicode`, {method: 'GET'})
+      .then((res) => fn1(res))
+      .then((data) => fn2(data))
   }
 
   let promises =
-  [
-    get((res) => res.json(), (json) => {
-      report(<Assert key="json data correct" expect={'你好!'} actual={json.data}/>)
-    }),
-    get((res) => res.text(), (text) => {
-      report(<Assert key="text data correct" expect={'你好!'} actual={JSON.parse(text).data}/>)
-    }),
-    get((res) => res.blob(), (blob) => {
-      return blob.readBlob('utf8').then((text) => {
-        report(<Assert key="blob data correct" expect={'你好!'} actual={JSON.parse(text).data}/>)
-      })
-    }),
-    // get((res) => res.arrayBuffer(), (text) => {
-    //   report(<Assert key="text data correct" expect={'你好!'} actual={JSON.parse(text).data}/>)
-    // })
-  ]
+    [
+      get((res) => res.json(), (json) => {
+        report(<Assert key="json data correct" expect={'你好!'} actual={json.data}/>)
+      }),
+      get((res) => res.text(), (text) => {
+        report(<Assert key="text data correct" expect={'你好!'} actual={JSON.parse(text).data}/>)
+      }),
+      get((res) => res.blob(), (blob) => {
+        return blob.readBlob('utf8').then((text) => {
+          report(<Assert key="blob data correct" expect={'你好!'} actual={JSON.parse(text).data}/>)
+        })
+      }),
+      // get((res) => res.arrayBuffer(), (text) => {
+      //   report(<Assert key="text data correct" expect={'你好!'} actual={JSON.parse(text).data}/>)
+      // })
+    ]
 
-  Promise.all(promises).then(() => {
-    done()
-  })
-
+  Promise.all(promises)
+    .then(() => done())
+    .catch(err => {
+      report(<Assert key="Error" expect={null} actual={err}/>)
+      done()
+    })
 })
 
 describe('GET request test : path -> any', (report, done) => {
-
   function get(fn1, fn2, fn3) {
-    fetch(`${TEST_SERVER_URL}/public/github.png`, { method : 'GET'})
+    fetch(`${TEST_SERVER_URL}/public/github.png`, {method: 'GET'})
       .then((res) => fn1(res))
       .then((data) => fn2(data))
       .catch((err) => fn3(err))
   }
+
   let contentLength = 0
   let isIOS = Platform.OS === 'ios'
+
   let promises = [
     // FIXME: IOS only
-    // https://github.com/facebook/react-native/issues/9178
-    get((res) => {
-      if(isIOS)
-        return res.json()
-      return Promise.resolve()
-    }, (data) => {
-      report(<Assert key="should not convert blob to JSON (IOS only)" expect={true} actual={false} />)
-    }, (err) => {
-      report(<Assert key="should not convert blob to JSON (IOS only)" expect={true} actual={true} />)
-    }),
-    // FIXME: IOS only
-    // https://github.com/facebook/react-native/issues/9178
-    get((res) => {
-      contentLength = res.headers['Content-Length']
-      if(isIOS)
+    // https://github.com/facebook/react-native/issues/10756
+    get(
+      (res) => isIOS ? res.json() : Promise.resolve(),
+      (data) => {
+        report(<Assert key="should not convert blob to JSON (IOS only)" expect={true} actual={false}/>)
+      },
+      (err) => {
+        report(<Assert key="should not convert blob to JSON (IOS only)" expect={true} actual={true}/>)
+      }
+    ),
+    get(
+      (res) => {
+        contentLength = res.headers['Content-Length']
         return res.text()
-      return Promise.resolve()
-
-    }, (data) => {
-      try {
-        report(<Assert key="content length should correct (IOS only)" expect={Math.floor(contentLength)} actual={data ? data.length : 0} />)
-      } catch(e){}
-    }, (err) => {
-      console.warn(err, err.stack)
-    }),
-    get((res) => {
-      contentLength = res.headers['Content-Length']
-      return res.blob()
-    }, (blob) => {
-      return fs.stat(blob._ref).then((stat) => {
-        report(<Assert key="stored file size correct" expect={contentLength} actual={stat.size} />)
-        return blob.readBlob('base64')
-      })
-      .then((b64) => {
-        report(<Info key="stored image">
-          <Image style={styles.image} source={{uri : 'data:image/png;BASE64 ,' + b64}}/>
-        </Info>)
-      })
-
-    }, (err) => {
-      console.warn(err, err.stack)
-    })
+      },
+      (data) => {
+        report(<Assert key="content length should correct" expect={+contentLength} actual={data ? data.length : 0}/>)
+      },
+      (err) => {
+        console.warn(err, err.stack)
+      }
+    ),
+    get(
+      (res) => {
+        contentLength = res.headers['Content-Length']
+        return res.blob()
+      },
+      (blob) => {
+        return fs.stat(blob._ref)
+          .then((stat) => {
+            report(<Assert key="stored file size correct" expect={+contentLength} actual={stat.size}/>)
+            return blob.readBlob('base64')
+          })
+          .then((b64) => {
+            report(<Assert key="BASE64 encoded size correct" expect={31968} actual={b64.length}/>)
+            report(<Info key="stored image">
+              <Image style={styles.image} source={{uri: 'data:image/png;base64,' + b64}}/>
+            </Info>)
+          })
+      },
+      (err) => {
+        console.warn(err, err.stack)
+      }
+    )
   ]
-  Promise.all(promises).then( () => done() )
 
+  Promise.all(promises)
+    .then(() => done())
+    .catch(err => {
+      report(<Assert key="Error" expect={null} actual={err}/>)
+      done()
+    })
 })
 
 describe('POST different kinds of body', (report, done) => {
-
   let image = RNTest.prop('image')
   let tmpPath = dirs.DocumentDir + '/tmp-' + Date.now()
 
   function upload(desc, pBody) {
     let name = `fetch-replacement-${Platform.OS}-${Date.now()}-${Math.random()}.png`
     return pBody.then((body) =>
-      fetch('https://content.dropboxapi.com/2/files/upload', {
-        method : 'post',
-        headers : {
-          Authorization : `Bearer ${DROPBOX_TOKEN}`,
-          'Dropbox-API-Arg': '{\"path\": \"/rn-upload/'+name+'\",\"mode\": \"add\",\"autorename\": true,\"mute\": false}',
-          'Content-Type' : 'application/octet-stream'
-        },
-        body})
-    )
-    .then((res) => {
-      return res.json()
-    })
-    .then((info) => {
-      report(<Assert key={desc} expect={name} actual={info.name}/>)
-    })
+        fetch('https://content.dropboxapi.com/2/files/upload', {
+          method: 'post',
+          headers: {
+            Authorization: `Bearer ${DROPBOX_TOKEN}`,
+            'Dropbox-API-Arg': '{\"path\": \"/rn-upload/' + name + '\",\"mode\": \"add\",\"autorename\": true,\"mute\": false}',
+            'Content-Type': 'application/octet-stream'
+          },
+          body
+        })
+      )
+      .then((res) => {
+        return res.json()
+      })
+      .then((info) => {
+        report(<Assert key={desc} expect={name} actual={info.name}/>)
+      })
+      .catch(err => report(<Assert key="Error" expect={null} actual={err}/>))
   }
 
   fetch(`${TEST_SERVER_URL}/public/github2.jpg`)
@@ -161,56 +163,58 @@ describe('POST different kinds of body', (report, done) => {
       ]
       Promise.all(tests).then(() => done())
     })
-
+    .catch(err => {
+      report(<Assert key="Error" expect={null} actual={err}/>)
+      done()
+    })
 })
 
 describe('Request header correctness', (report, done) => {
-
   let expect = {
-    'hello' : 'world',
-    'Content-Type' : 'application/json',
-    'foo' : encodeURIComponent('福' + Date.now())
+    'hello': 'world',
+    'Content-Type': 'application/json',
+    'foo': encodeURIComponent('福' + Date.now())
   }
 
-  fetch(`${TEST_SERVER_URL}/xhr-header`, {
-    method : 'GET',
-    headers : expect
-  })
-  .then((res) => res.json())
-  .then((actual) => {
-    report(<Info key={JSON.stringify(actual)}/>)
-    report(<Assert key="header field test #1" expect={expect.hello} actual={actual.hello}/>)
-    report(<Assert key="header field test #2" expect={expect['content-type']} actual={actual['content-type']}/>)
-    report(<Assert key="header field test #3" expect={expect.foo} actual={actual.foo}/>)
-    done()
-  })
-
+  fetch(`${TEST_SERVER_URL}/xhr-header`, {method: 'GET', headers: expect})
+    .then((res) => res.json())
+    .then((actual) => {
+      report(<Info key={JSON.stringify(actual)}/>)
+      report(<Assert key="header field test #1" expect={expect.hello} actual={actual.hello}/>)
+      report(<Assert key="header field test #2" expect={expect['content-type']} actual={actual['content-type']}/>)
+      report(<Assert key="header field test #3" expect={expect.foo} actual={actual.foo}/>)
+      done()
+    })
+    .catch(err => {
+      report(<Assert key="Error" expect={null} actual={err}/>)
+      done()
+    })
 })
 
 describe('Upload form data ', (report, done) => {
-
   let form = new FormData()
   let expectName = 'fetch-replacement-test' + new Date()
   File
-  .build('test-image.png', RNTest.prop('image'), { type : 'image/png;BASE64' })
-  .then((file) => {
-
-    form.append('name', expectName)
-    form.append('file', file)
-    return fetch(`${TEST_SERVER_URL}/upload-form`, {
-      method : 'POST',
-      body : form
+    .build('test-image.png', RNTest.prop('image'), {type: 'image/png;BASE64'})
+    .then((file) => {
+      form.append('name', expectName)
+      form.append('file', file)
+      return fetch(`${TEST_SERVER_URL}/upload-form`, {
+        method: 'POST',
+        body: form
+      })
     })
-
-  })
-  .then((res) => res.json())
-  .then((json) => {
-    report(
-      <Assert key="form data verify" expect={expectName} actual={json.fields.name}/>,
-      <Assert key="file size verify" expect={23975} actual={json.files[0].size}/>,
-      <Assert key="form data file name verify" expect={'test-image.png'} actual={json.files[0].originalname}/>
-    )
-    done()
-  })
-
+    .then((res) => res.json())
+    .then((json) => {
+      report(
+        <Assert key="form data verify" expect={expectName} actual={json.fields.name}/>,
+        <Assert key="file size verify" expect={23975} actual={json.files[0].size}/>,
+        <Assert key="form data file name verify" expect={'test-image.png'} actual={json.files[0].originalname}/>
+      )
+      done()
+    })
+    .catch(err => {
+      report(<Assert key="Error" expect={null} actual={err}/>)
+      done()
+    })
 })

--- a/test/test-fs.js
+++ b/test/test-fs.js
@@ -2,36 +2,30 @@ import RNTest from './react-native-testkit/'
 import React from 'react'
 import RNFetchBlob from 'react-native-fetch-blob'
 
-import {
-  StyleSheet,
-  Text,
-  View,
-  ScrollView,
-  Platform,
-  Dimensions,
-  Image,
-} from 'react-native';
-const { Assert, Comparer, Info, prop } = RNTest
+import {Dimensions, Image, Platform, ScrollView, StyleSheet, Text, View,} from 'react-native';
+
+const {Assert, Comparer, Info, prop} = RNTest
 const fs = RNFetchBlob.fs
 const describe = RNTest.config({
-  group : 'fs',
-  expand : false,
-  run : true
+  group: 'fs',
+  expand: false,
+  run: true
 })
 
-let { TEST_SERVER_URL, FILENAME, DROPBOX_TOKEN, styles, image } = prop()
+let {TEST_SERVER_URL, FILENAME, DROPBOX_TOKEN, styles, image} = prop()
 let dirs = RNFetchBlob.fs.dirs
 let prefix = ((Platform.OS === 'android') ? 'file://' : '')
 
 describe('Get storage folders', (report, done) => {
   report(
     <Assert key="system folders should exists"
-      expect={dirs}
-      comparer={Comparer.exists} />,
+            expect={dirs}
+            comparer={Comparer.exists}
+    />,
     <Assert key="check properties"
-      expect={['DocumentDir', 'CacheDir']}
-      comparer={Comparer.hasProperties}
-      actual={dirs}
+            expect={['DocumentDir', 'CacheDir']}
+            comparer={Comparer.hasProperties}
+            actual={dirs}
     />,
     <Info key="System Folders">
       <Text>{`${JSON.stringify(dirs)}`}</Text>
@@ -42,30 +36,30 @@ describe('Get storage folders', (report, done) => {
 
 describe('ls API test', (report, done) => {
   fs.ls(dirs.DocumentDir).then((list) => {
-    report(<Assert key="result must be an Array" expect={true} actual={Array.isArray(list)} />)
+    report(<Assert key="result must be an Array" expect={true} actual={Array.isArray(list)}/>)
     return fs.ls('hh87h8uhi')
   })
-  .then(()=>{})
+  .then(() => {
+  })
   .catch((err) => {
-    report(<Assert key="Wrong path should have error"
-      expect={err}
-      comparer={Comparer.exists}/>)
+    report(<Assert key="Wrong path should have error" expect={err} comparer={Comparer.exists}/>)
     done()
   })
 })
 
 describe('exists API test', (report, done) => {
   let exists = fs.exists
-  exists(dirs.DocumentDir).then((exist, isDir) => {
-    report(
-      <Assert key="document dir should exist" expect={true} actual={exist}/>
-    )
+  exists(dirs.DocumentDir)
+  .then((exist, isDir) => {
+    report(<Assert key="document dir should exist" expect={true} actual={exist}/>)
     return exists('blabajsdio')
   })
   .then((exist, isDir) => {
-    report(
-      <Assert key="path should not exist" expect={false} actual={exist}/>
-    )
+    report(<Assert key="path should not exist" expect={false} actual={exist}/>)
+    done()
+  })
+  .catch(err => {
+    report(<Assert key="Error" expect={null} actual={err}/>)
     done()
   })
 })
@@ -76,162 +70,171 @@ describe('create file API test', (report, done) => {
   let base64 = RNFetchBlob.base64.encode(raw)
 
   fs.createFile(p, raw, 'utf8')
-    .then(() => {
+  .then(() => fs.readStream(p, 'utf8'))
+  .then((stream) => {
+    let d = ''
+    stream.open()
+    stream.onData((chunk) => {
+      d += chunk
+    })
+    stream.onError((detail) => {
+      // Outside the promise
+      throw new Error(detail)
+    })
+    stream.onEnd(() => {
+      report(<Assert key="utf8 content test" expect={raw} actual={d}/>)
+      testBase64()
+    })
+  })
+  .catch(err => {
+    report(<Assert key="Error" expect={null} actual={err}/>)
+    done()
+  })
+
+  function testBase64 () {
+    fs.createFile(p + '-base64', RNFetchBlob.base64.encode(raw), 'base64')
+    .then(() => fs.readStream(p + '-base64', 'utf8'))
+    .then((stream) => {
       let d = ''
-      fs.readStream(p, 'utf8').then((stream) => {
-        stream.open()
-        stream.onData((chunk) => {
-          d += chunk
-        })
-        stream.onEnd(() => {
-          report(<Assert key="utf8 content test"  expect={raw} actual={d}/>)
-          testBase64()
-        })
+      stream.open()
+      stream.onData((chunk) => {
+        d += chunk
+      })
+      stream.onError((detail) => {
+        // Outside the promise
+        throw new Error(detail)
+      })
+      stream.onEnd(() => {
+        report(
+          <Assert key="base64 content test" expect={raw} actual={d}/>)
+        done()
       })
     })
-  function testBase64() {
-    fs.createFile(p + '-base64', RNFetchBlob.base64.encode(raw), 'base64')
-      .then(() => {
-        fs.readStream(p + '-base64', 'utf8').then((stream) => {
-            stream.open()
-            let d = ''
-            stream.onData((chunk) => {
-              d += chunk
-            })
-            stream.onEnd(() => {
-              report(
-                <Assert
-                  key="base64 content test"
-                  expect={raw}
-                  actual={d}/>)
-                done()
-              })
-        })
-      })
-      .catch((err) => {
-        console.log(err)
-      })
+    .catch(err => {
+      report(<Assert key="Error" expect={null} actual={err}/>)
+      done()
+    })
   }
-
 })
 
 describe('mkdir and isDir API test', (report, done) => {
   let p = dirs.DocumentDir + '/mkdir-test-' + Date.now()
   fs.mkdir(p).then((err) => {
-    report(<Assert key="folder should be created without error"
-      expect={undefined}
-      actual={err} />)
+    report(<Assert key="folder should be created without error" expect={true} actual={err}/>)
     return fs.exists(p)
   })
   .then((exist) => {
-    report(<Assert key="mkdir should work correctly" expect={true} actual={exist} />)
+    report(<Assert key="mkdir should work correctly" expect={true} actual={exist}/>)
     return fs.isDir(p)
   })
   .then((isDir) => {
-    report(<Assert key="isDir should work correctly" expect={true} actual={isDir} />)
+    report(<Assert key="isDir should work correctly" expect={true} actual={isDir}/>)
     return fs.mkdir(p)
   })
-  .then()
   .catch((err) => {
-    report(<Assert key="isDir should not work when folder exists"
-      expect={err}
-      comparer={Comparer.hasValue}/>)
+    report(<Assert key="isDir should not work when folder exists" expect={err} comparer={Comparer.hasValue}/>)
     done()
   })
 })
 
 describe('unlink and mkdir API test', (report, done) => {
   let p = dirs.DocumentDir + '/unlink-test-' + Date.now()
-  fs.createFile(p, 'write' + Date.now(), 'utf8').then(() => {
-    return fs.exists(p)
-  })
+  fs.createFile(p, 'write' + Date.now(), 'utf8')
+  .then(() => fs.exists(p))
   .then((exist) => {
-    report(<Assert key="file created" expect={true} actual={exist} />)
-    return fs.unlink(p).then(() => {
-      return fs.exists(p)
-    })
+    report(<Assert key="file created" expect={true} actual={exist}/>)
+    return fs.unlink(p)
   })
+  .then(() => fs.exists(p))
   .then((exist) => {
-    report(<Assert key="file removed" expect={false} actual={exist} />)
+    report(<Assert key="file removed" expect={false} actual={exist}/>)
     return fs.mkdir(p + '-dir')
   })
-  .then((err) => fs.exists(p + '-dir'))
+  .then(() => fs.exists(p + '-dir'))
   .then((exist) => {
-    report(<Assert key="mkdir should success" expect={true} actual={exist} />)
+    report(<Assert key="mkdir should success" expect={true} actual={exist}/>)
     return fs.unlink(p + '-dir')
   })
   .then(() => fs.exists(p + '-dir'))
   .then((exist) => {
-    report(<Assert key="folder should be removed" expect={false} actual={exist} />)
+    report(<Assert key="folder should be removed" expect={false} actual={exist}/>)
+    done()
+  })
+  .catch(err => {
+    report(<Assert key="Error" expect={null} actual={err}/>)
     done()
   })
 })
 
 describe('write stream API test', (report, done) => {
-
   let p = dirs.DocumentDir + '/write-stream' + Date.now()
   let expect = ''
   fs.createFile(p, '1234567890', 'utf8')
-    .then(() => fs.writeStream(p, 'utf8', true))
-    .then((ws) => {
-      ws.write('11')
-      ws.write('12')
-      ws.write('13')
-      ws.write('14')
-      return ws.close()
+  .then(() => fs.writeStream(p, 'utf8', true))
+  .then((ws) => {
+    ws.write('11')
+    ws.write('12')
+    ws.write('13')
+    ws.write('14')
+    return ws.close()
+  })
+  .then(() => fs.readStream(p, 'utf8'))
+  .then((stream) => {
+    let d1 = ''
+    stream.open()
+    stream.onData((chunk) => {
+      d1 += chunk
     })
-    .then(() => {
-      let d1 = ''
-      fs.readStream(p, 'utf8').then((stream) => {
-        stream.open()
-        stream.onData((chunk) => {
-          d1 += chunk
-        })
-        stream.onEnd(() => {
-          report(
-            <Assert key="write data async test"
-              expect={'123456789011121314'}
-              actual={d1}/>)
-            base64Test()
-        })
-      })
+    stream.onError((detail) => {
+      // Outside the promise
+      throw new Error(detail)
     })
-  function base64Test() {
+    stream.onEnd(() => {
+      report(<Assert key="write data async test" expect={'123456789011121314'} actual={d1}/>)
+      return base64Test()
+    })
+  })
+  .catch(err => {
+    report(<Assert key="Error" expect={null} actual={err}/>)
+    done()
+  })
+
+  function base64Test () {
     fs.writeStream(p, 'base64', false)
     .then((ws) => {
-      for(let i = 0; i< 100; i++) {
+      for (let i = 0; i < 100; i++) {
         expect += String(i)
       }
       ws.write(RNFetchBlob.base64.encode(expect))
       return ws.close()
     })
-    .then(() => {
-      return fs.readStream(p, 'base64')
-    })
+    .then(() => fs.readStream(p, 'base64'))
     .then((stream) => {
       let d2 = ''
       stream.open()
       stream.onData((chunk) => {
         d2 += chunk
       })
+      stream.onError((detail) => {
+        // Outside the promise
+        throw new Error(detail)
+      })
       stream.onEnd(() => {
-        report(
-          <Assert key="file should be overwritten by base64 encoded data"
-            expect={RNFetchBlob.base64.encode(expect)}
-            actual={d2} />)
+        report(<Assert key="file should be overwritten by base64 encoded data"
+                       expect={RNFetchBlob.base64.encode(expect)} actual={d2}/>)
         done()
       })
     })
   }
 })
 
-describe('mv API test', {timeout : 10000},(report, done) => {
+describe('mv API test', {timeout: 10000}, (report, done) => {
   let p = dirs.DocumentDir + '/mvTest' + Date.now()
   let dest = p + '-dest-' + Date.now()
   let content = Date.now() + '-test'
   fs.createFile(p, content, 'utf8')
   .then(() => fs.mkdir(dest))
-  .then(() => fs.mv(p, dest +'/moved'))
+  .then(() => fs.mv(p, dest + '/moved'))
   .then(() => fs.exists(p))
   .then((exist) => {
     report(<Assert key="file should not exist in old path" expect={false} actual={exist}/>)
@@ -243,83 +246,101 @@ describe('mv API test', {timeout : 10000},(report, done) => {
   })
   .then((files) => {
     report(<Assert key="file name should be correct" expect={'moved'} actual={files[0]}/>)
-    fs.readStream(dest + '/moved').then((rs) => {
-      rs.open()
-      let actual = ''
-      rs.onData((chunk) => {
-        actual += chunk
-      })
-      rs.onEnd(() => {
-        report(<Assert key="file content should be correct" expect={content} actual={actual}/>)
-        done()
-      })
+    return fs.readStream(dest + '/moved')
+  })
+  .then((stream) => {
+    let actual = ''
+    stream.open()
+    stream.onData((chunk) => {
+      actual += chunk
     })
+    stream.onError((detail) => {
+      // Outside the promise
+      throw new Error(detail)
+    })
+    stream.onEnd(() => {
+      report(<Assert key="file content should be correct" expect={content} actual={actual}/>)
+      done()
+    })
+  })
+  .catch(err => {
+    report(<Assert key="Error" expect={null} actual={err}/>)
+    done()
   })
 })
 
-describe('cp API test', {timeout : 10000},(report, done) => {
+describe('cp API test', {timeout: 10000}, (report, done) => {
   let p = dirs.DocumentDir + '/cpTest' + Date.now()
   let dest = p + '-dest-' + Date.now()
   let content = Date.now() + '-test'
   fs.createFile(p, content, 'utf8')
   .then(() => fs.mkdir(dest))
-  .then(() => fs.cp(p, dest +'/cp'))
-  .then(() => fs.exists(dest +'/cp'))
+  .then(() => fs.cp(p, dest + '/cp'))
+  .then(() => fs.exists(dest + '/cp'))
   .then((exist) => {
     report(<Assert key="file should be copy to destination" expect={true} actual={exist}/>)
     return fs.ls(dest)
   })
   .then((files) => {
     report(<Assert key="file name should be correct" expect={'cp'} actual={files[0]}/>)
-    fs.readStream(dest + '/cp').then((rs) => {
-      rs.open()
-      let actual = ''
-      rs.onData((chunk) => {
-        actual += chunk
-      })
-      rs.onEnd(() => {
-        report(<Assert key="file content should be correct" expect={content} actual={actual}/>)
-        done()
-      })
+    return fs.readStream(dest + '/cp')
+  })
+  .then((stream) => {
+    let actual = ''
+    stream.open()
+    stream.onData((chunk) => {
+      actual += chunk
     })
+    stream.onError((detail) => {
+      // Outside the promise
+      throw new Error(detail)
+    })
+    stream.onEnd(() => {
+      report(<Assert key="file content should be correct" expect={content} actual={actual}/>)
+      done()
+    })
+  })
+  .catch(err => {
+    report(<Assert key="Error" expect={null} actual={err}/>)
+    done()
   })
 })
 
 describe('ASCII data test', (report, done) => {
   let p = dirs.DocumentDir + '/ASCII-test-' + Date.now()
-  let expect = 'fetch-blob-'+Date.now()
+  let expect = 'fetch-blob-' + Date.now()
 
   fs.createFile(p, 'utf8')
-    .then(() => {
-      return fs.writeStream(p, 'ascii', false)
+  .then(() => fs.writeStream(p, 'ascii', false))
+  .then((ofstream) => {
+    for (let i = 0; i < expect.length; i++) {
+      ofstream.write([expect[i].charCodeAt(0)])
+    }
+    ofstream.write(['g'.charCodeAt(0), 'g'.charCodeAt(0)])
+    return ofstream.close()
+  })
+  .then(() => fs.readStream(p, 'ascii'))
+  .then((stream) => {
+    let res = []
+    stream.open()
+    stream.onData((chunk) => {
+      res = res.concat(chunk)
     })
-    .then((ofstream) => {
-      for(let i=0;i<expect.length;i++) {
-        ofstream.write([expect[i].charCodeAt(0)])
-      }
-      ofstream.write(['g'.charCodeAt(0), 'g'.charCodeAt(0)])
-      return ofstream.close()
+    stream.onError((detail) => {
+      // Outside the promise
+      throw new Error(detail)
     })
-    .then(() => {
-      fs.readStream(p, 'ascii').then((ifstream) => {
-        let res = []
-        ifstream.open()
-        ifstream.onData((chunk) => {
-          res = res.concat(chunk)
-        })
-        ifstream.onEnd(() => {
-          res = res.map((byte) => {
-            return String.fromCharCode(byte)
-          }).join('')
-          report(
-            <Assert key="data written in ASCII format should correct"
-              expect={expect + 'gg'}
-              actual={res}
-            />)
-              done()
-            })
-      })
+    stream.onEnd(() => {
+      res = res.map((byte) => String.fromCharCode(byte)).join('')
+      report(
+        <Assert key="data written in ASCII format should correct" expect={expect + 'gg'} actual={res}/>)
+      done()
     })
+  })
+  .catch(err => {
+    report(<Assert key="Error" expect={null} actual={err}/>)
+    done()
+  })
 })
 
 describe('ASCII file test', (report, done) => {
@@ -330,87 +351,88 @@ describe('ASCII file test', (report, done) => {
   filename = 'ASCII-file-test' + Date.now() + '.txt'
   expect = 'ascii test ' + Date.now()
   fs.createFile(p + filename, getASCIIArray(expect), 'ascii')
-    .then(() => {
-      fs.readStream(p + filename, 'base64').then((rs) => {
-        let actual = ''
-        rs.open()
-        rs.onData((chunk) => {
-          actual += chunk
-        })
-        rs.onEnd(() => {
-          report(<Assert key="written data verify"
-            expect={expect}
-            actual={base64.decode(actual)}/>)
-          done()
-        })
-      })
+  .then(() => fs.readStream(p + filename, 'base64'))
+  .then((stream) => {
+    let actual = ''
+    stream.open()
+    stream.onData((chunk) => {
+      actual += chunk
     })
+    stream.onError((detail) => {
+      // Outside the promise
+      throw new Error(detail)
+    })
+    stream.onEnd(() => {
+      report(<Assert key="written data verify" expect={expect} actual={base64.decode(actual)}/>)
+      done()
+    })
+  })
+  .catch(err => {
+    report(<Assert key="Error" expect={null} actual={err}/>)
+    done()
+  })
 })
 
 describe('format conversion', (report, done) => {
   let p = dirs.DocumentDir + '/foo-' + Date.now()
   fs.createFile(p, [102, 111, 111], 'ascii')
-    .then(() => {
-      fs.readStream(p, 'utf8').then((stream) => {
-        let res = []
-        stream.open()
-        stream.onData((chunk) => {
-          res+=chunk
-        })
-        stream.onEnd(() => {
-          report(
-            <Assert key="write utf8 and read by ascii"
-              expect="foo"
-              actual={res}/>)
-              done()
-        })
-      })
+  .then(() => fs.readStream(p, 'utf8'))
+  .then((stream) => {
+    let res = []
+    stream.open()
+    stream.onData((chunk) => {
+      res += chunk
     })
+    stream.onError((detail) => {
+      // Outside the promise
+      throw new Error(detail)
+    })
+    stream.onEnd(() => {
+      report(<Assert key="write utf8 and read by ascii" expect="foo" actual={res}/>)
+      done()
+    })
+  })
+  .catch(err => {
+    report(<Assert key="Error" expect={null} actual={err}/>)
+    done()
+  })
 })
 
 describe('stat and lstat test', (report, done) => {
   let p = dirs.DocumentDir + '/' + 'ls-stat-test' + Date.now()
   let file = null
 
-  fs.lstat(dirs.DocumentDir)
-  // stat a folder
+  fs.lstat(dirs.DocumentDir)  // stat a folder
   .then((stat) => {
-    report(
-      <Assert key="result should be an array"
-        expect={true}
-        actual={Array.isArray(stat)}/>)
+    report(<Assert key="result should be an array" expect={true} actual={Array.isArray(stat)}/>)
     file = stat[0].path
-    return fs.stat(file)
+    return fs.stat(file)  // stat a file
   })
   .then((stat) => {
-    report(
-      <Assert key="should have properties"
-        expect={['size', 'type', 'lastModified', 'filename', 'path']}
-        comparer={Comparer.hasProperties}
-        actual={stat}/>)
+    report(<Assert key="should have properties" expect={['size', 'type', 'lastModified', 'filename', 'path']}
+                   comparer={Comparer.hasProperties} actual={stat}/>)
     return fs.stat('13123132')
   })
-  .then(()=>{})
+  .then(() => {
+    // TODO ???
+  })
   .catch((err) => {
     console.log(err)
-    report(<Assert key="stat error catacable"
-      expect={true}
-      actual={true}/>)
+    report(<Assert key="stat error catacable" expect={true} actual={true}/>)
     done()
   })
-  .then(()=>{})
+  .then(() => {
+    // TODO ???
+  })
   .catch((err) => {
     console.log(err)
-    report(<Assert key="lstat error catacable"
-      expect={true}
-      actual={true}/>)
+    report(<Assert key="lstat error catacable" expect={true} actual={true}/>)
     done()
   })
 
 })
 
 describe('fs.slice test', (report, done) => {
-
   let source = null
   let parts = fs.dirs.DocumentDir + '/tmp-source-'
   let dests = []
@@ -418,8 +440,8 @@ describe('fs.slice test', (report, done) => {
   let size = 0
 
   window.fetch = new RNFetchBlob.polyfill.Fetch({
-    auto : true,
-    binaryContentTypes : ['image/', 'video/', 'audio/']
+    auto: true,
+    binaryContentTypes: ['image/', 'video/', 'audio/']
   }).build()
 
   fetch(`${TEST_SERVER_URL}/public/github2.jpg`)
@@ -433,16 +455,16 @@ describe('fs.slice test', (report, done) => {
     size = stat.size
     let promise = Promise.resolve()
     let cursor = 0
-    while(cursor < size) {
-      promise = promise.then(function(start) {
-        console.log('slicing part ', start , start + 40960)
+    while (cursor < size) {
+      promise = promise.then(function (start) {
+        console.log('slicing part ', start, start + 40960)
         let offset = 0
         return fs.slice(source, parts + start, start + offset, start + 40960)
-                .then((dest) => {
-                  console.log('slicing part ', start + offset, start + 40960, 'done')
-                  dests.push(dest)
-                  return Promise.resolve()
-                })
+        .then((dest) => {
+          console.log('slicing part ', start + offset, start + 40960, 'done')
+          dests.push(dest)
+          return Promise.resolve()
+        })
       }.bind(this, cursor))
       cursor += 40960
     }
@@ -453,8 +475,8 @@ describe('fs.slice test', (report, done) => {
   .then(() => {
     console.log('combinding files')
     let p = Promise.resolve()
-    for(let d in dests) {
-      p = p.then(function(chunk){
+    for (let d in dests) {
+      p = p.then(function (chunk) {
         return fs.appendFile(combined, chunk, 'uri').then((write) => {
           console.log(write, 'bytes write')
         })
@@ -466,46 +488,98 @@ describe('fs.slice test', (report, done) => {
     report(
       <Assert key="verify file size" expect={size} actual={stat.size}/>,
       <Info key="image viewer">
-        <Image key="combined image" style={styles.image} source={{ uri : prefix + combined}}/>
-      </Info>)
+        <Image key="combined image" style={styles.image} source={{uri: prefix + combined}}/>
+      </Info>
+    )
+    done()
+  })
+  .catch(err => {
+    report(<Assert key="Error" expect={null} actual={err}/>)
+    done()
+  })
+})
+
+describe('hash API test', (report, done) => {
+  const txtFile = dirs.DocumentDir + '/hash-test-txt-' + Date.now()
+  let binFile;
+
+  fetch(`${TEST_SERVER_URL}/public/github2.jpg`)
+  .then((res) => res.rawResp())
+  .then((res) => {
+    binFile = res.path()
+  })
+  .then(() => fs.createFile(txtFile, 'What is SHA-256? The SHA (Secure Hash Algorithm) is one of a number of cryptographic hash functions.', 'utf8'))
+  .then(() => fs.hash(txtFile, 'md5'))
+  .then((hash) => {
+    report(<Assert key="MD5 hash of text file should be created" expect={'3fce512da59b4abda4c5f37ef7859443'} actual={hash}/>)
+  })
+  .then(() => fs.hash(txtFile, 'sha256'))
+  .then((hash) => {
+    report(<Assert key="SHA-256 hash of text file should be created" expect={'92fc68e5477e96c2beac69237bb8449350a358bd5a6fe578d1b374814b1f4486'} actual={hash}/>)
+  })
+  .then(() => fs.hash(binFile, 'md5'))
+  .then((hash) => {
+    report(<Assert key="MD5 hash of binary file should be created" expect={'c7e6697f842252de45eb70eb6314987a'} actual={hash}/>)
+  })
+  .then(() => fs.hash(binFile, 'sha256'))
+  .then((hash) => {
+    report(<Assert key="SHA-256 hash of binary file should be created" expect={'ffb5be2160cc5d594378a71e187ccfe06b0829877721e285669c01467c175ca7'} actual={hash}/>)
+  })
+  .then(() => invalidFilenameCheck())
+  .then(() => invalidAlgorithmCheck())
+  .then(() => done())
+  .catch(err => {
+    report(<Assert key="Error" expect={null} actual={err}/>)
     done()
   })
 
+  function invalidFilenameCheck () {
+    return fs.hash('INVALID_FILE', 'sha256')
+    .then(() => report(<Assert key="should have reported 'file not found'" expect={true} actual={false}/>))
+    .catch((err) => {
+      report(<Assert key="Non-existing file should cause error" expect={'ENOENT'} actual={err.code}/>)
+    })
+  }
+
+  function invalidAlgorithmCheck () {
+    return fs.hash(binFile, 'INVALID')
+    .then(() => report(<Assert key="should have reported 'invalid algorithm'" expect={true} actual={false}/>))
+    .catch((err) => {
+      report(<Assert key="Invalid hash algorithm should cause error" expect={'EINVAL'} actual={err.code}/>)
+    })
+  }
 })
 
-describe('#135 binary data to ascii file size checking', (report, done) => {
-
+describe('binary data to ascii file size checking', (report, done) => {
   let file = null
   let expectedSize = 0
 
-  RNFetchBlob.config({ fileCache : true })
-    .fetch('GET', `${TEST_SERVER_URL}/public/beethoven.mp3`)
-    .then((res) => {
-      file = res.path()
-      return fs.stat(file)
+  RNFetchBlob.config({fileCache: true})
+  .fetch('GET', `${TEST_SERVER_URL}/public/beethoven.mp3`)
+  .then((res) => {
+    file = res.path()
+    return fs.stat(file)
+  })
+  .then((stat) => {
+    expectedSize = Math.floor(stat.size)
+    return fs.readStream(file, 'ascii')
+  })
+  .then((stream) => {
+    let actual = 0
+    stream.open()
+    stream.onData((chunk) => {
+      actual += chunk.length
     })
-    .then((stat) => {
-      expectedSize = Math.floor(stat.size)
-      return fs.readStream(file, 'ascii')
+    stream.onEnd(() => {
+      report(<Assert key="check mp3 file size" expect={expectedSize} actual={actual}/>)
+      done()
     })
-    .then((stream) => {
-      let actual = 0
-      stream.open()
-      stream.onData((chunk) => {
-        actual += chunk.length
-      })
-      stream.onEnd(() => {
-        report(<Assert key="check mp3 file size" expect={expectedSize} actual={actual}/>)
-        done()
-      })
-    })
-
+  })
 })
 
-
-function getASCIIArray(str) {
+function getASCIIArray (str) {
   let r = []
-  for(let i=0;i<str.length;i++) {
+  for (let i = 0; i < str.length; i++) {
     r.push(str[i].charCodeAt(0))
   }
   return r

--- a/test/test-fs.js
+++ b/test/test-fs.js
@@ -18,15 +18,8 @@ let prefix = ((Platform.OS === 'android') ? 'file://' : '')
 
 describe('Get storage folders', (report, done) => {
   report(
-    <Assert key="system folders should exists"
-            expect={dirs}
-            comparer={Comparer.exists}
-    />,
-    <Assert key="check properties"
-            expect={['DocumentDir', 'CacheDir']}
-            comparer={Comparer.hasProperties}
-            actual={dirs}
-    />,
+    <Assert key="system folders should exists" expect={dirs} comparer={Comparer.exists}/>,
+    <Assert key="check properties" expect={['DocumentDir', 'CacheDir']} comparer={Comparer.hasProperties} actual={dirs}/>,
     <Info key="System Folders">
       <Text>{`${JSON.stringify(dirs)}`}</Text>
     </Info>
@@ -35,31 +28,59 @@ describe('Get storage folders', (report, done) => {
 })
 
 describe('ls API test', (report, done) => {
-  fs.ls(dirs.DocumentDir).then((list) => {
-    report(<Assert key="result must be an Array" expect={true} actual={Array.isArray(list)}/>)
-    return fs.ls('hh87h8uhi')
+  // Setup
+  let p = dirs.DocumentDir + '/unlink-test-' + Date.now()
+  fs.createFile(p, 'write' + Date.now(), 'utf8')
+  .then(() => fs.exists(p))
+  .catch((err) => {
+    report(<Assert key="Error creating file for test setup" expect={null} actual={err}/>)
+    done()
   })
-  .then(() => {
+
+  // Test - Directory (okay)
+  .then(() => fs.ls(dirs.DocumentDir))
+  .then((list) => {
+    report(<Assert key="result must be an Array" expect={true} actual={Array.isArray(list)}/>)
   })
   .catch((err) => {
-    report(<Assert key="Wrong path should have error" expect={err} comparer={Comparer.exists}/>)
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
+  // Test - File (error)
+  .then(() => fs.ls(p))
+  .then((list) => {
+    report(<Assert key="should have failed" expect={false} actual={true}/>)
+  })
+  .catch((err) => {
+    report(<Assert key="File instead of directory should fail" expect={'ENODIR'} actual={err.code}/>)
+  })
+
+  // Test - non-existent file (error)
+  .then(() => fs.ls('hh87h8uhi'))
+  .catch((err) => {
+    report(<Assert key="Wrong path should have error" expect={'ENOENT'} actual={err.code}/>)
     done()
   })
 })
 
 describe('exists API test', (report, done) => {
-  let exists = fs.exists
-  exists(dirs.DocumentDir)
-  .then((exist, isDir) => {
+  fs.exists(dirs.DocumentDir)
+  .then((exist) => {
     report(<Assert key="document dir should exist" expect={true} actual={exist}/>)
-    return exists('blabajsdio')
   })
-  .then((exist, isDir) => {
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
+  .then(() => fs.exists('blabajsdio'))
+  .then((exist) => {
     report(<Assert key="path should not exist" expect={false} actual={exist}/>)
     done()
   })
-  .catch(err => {
-    report(<Assert key="Error" expect={null} actual={err}/>)
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
     done()
   })
 })
@@ -77,17 +98,17 @@ describe('create file API test', (report, done) => {
     stream.onData((chunk) => {
       d += chunk
     })
-    stream.onError((detail) => {
+    stream.onError((err) => {
       // Outside the promise
-      throw new Error(detail)
+      report(<Assert key="Error" expect={null} actual={err}/>)
     })
     stream.onEnd(() => {
       report(<Assert key="utf8 content test" expect={raw} actual={d}/>)
       testBase64()
     })
   })
-  .catch(err => {
-    report(<Assert key="Error" expect={null} actual={err}/>)
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
     done()
   })
 
@@ -100,18 +121,17 @@ describe('create file API test', (report, done) => {
       stream.onData((chunk) => {
         d += chunk
       })
-      stream.onError((detail) => {
+      stream.onError((err) => {
         // Outside the promise
-        throw new Error(detail)
+        report(<Assert key="Error" expect={null} actual={err}/>)
       })
       stream.onEnd(() => {
-        report(
-          <Assert key="base64 content test" expect={raw} actual={d}/>)
+        report(<Assert key="base64 content test" expect={raw} actual={d}/>)
         done()
       })
     })
-    .catch(err => {
-      report(<Assert key="Error" expect={null} actual={err}/>)
+    .catch((err) => {
+      report(<Assert key="should not have failed" expect={null} actual={err}/>)
       done()
     })
   }
@@ -119,49 +139,81 @@ describe('create file API test', (report, done) => {
 
 describe('mkdir and isDir API test', (report, done) => {
   let p = dirs.DocumentDir + '/mkdir-test-' + Date.now()
-  fs.mkdir(p).then((err) => {
+
+  fs.mkdir(p)
+  .then((err) => {
     report(<Assert key="folder should be created without error" expect={true} actual={err}/>)
-    return fs.exists(p)
-  })
-  .then((exist) => {
-    report(<Assert key="mkdir should work correctly" expect={true} actual={exist}/>)
-    return fs.isDir(p)
-  })
-  .then((isDir) => {
-    report(<Assert key="isDir should work correctly" expect={true} actual={isDir}/>)
-    return fs.mkdir(p)
   })
   .catch((err) => {
-    report(<Assert key="isDir should not work when folder exists" expect={err} comparer={Comparer.hasValue}/>)
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
+  .then(() => fs.exists(p))
+  .then((exist) => {
+    report(<Assert key="mkdir should work correctly" expect={true} actual={exist}/>)
+  })
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
+  .then(() => fs.isDir(p))
+  .then((isDir) => {
+    report(<Assert key="isDir should work correctly" expect={true} actual={isDir}/>)
+  })
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+  })
+
+  .then(() => fs.mkdir(p))
+  .catch((err) => {
+    report(<Assert key="isDir should not work when folder exists" expect={'EEXIST'} actual={err.code}/>)
     done()
   })
 })
 
 describe('unlink and mkdir API test', (report, done) => {
   let p = dirs.DocumentDir + '/unlink-test-' + Date.now()
+
   fs.createFile(p, 'write' + Date.now(), 'utf8')
   .then(() => fs.exists(p))
   .then((exist) => {
     report(<Assert key="file created" expect={true} actual={exist}/>)
-    return fs.unlink(p)
   })
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
+  .then(() => fs.unlink(p))
   .then(() => fs.exists(p))
   .then((exist) => {
     report(<Assert key="file removed" expect={false} actual={exist}/>)
-    return fs.mkdir(p + '-dir')
   })
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
+  .then(() => fs.mkdir(p + '-dir'))
   .then(() => fs.exists(p + '-dir'))
   .then((exist) => {
     report(<Assert key="mkdir should success" expect={true} actual={exist}/>)
-    return fs.unlink(p + '-dir')
   })
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
+  .then(() => fs.unlink(p + '-dir'))
   .then(() => fs.exists(p + '-dir'))
   .then((exist) => {
     report(<Assert key="folder should be removed" expect={false} actual={exist}/>)
     done()
   })
-  .catch(err => {
-    report(<Assert key="Error" expect={null} actual={err}/>)
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
     done()
   })
 })
@@ -185,17 +237,17 @@ describe('write stream API test', (report, done) => {
     stream.onData((chunk) => {
       d1 += chunk
     })
-    stream.onError((detail) => {
+    stream.onError((err) => {
       // Outside the promise
-      throw new Error(detail)
+      report(<Assert key="Error" expect={null} actual={err}/>)
     })
     stream.onEnd(() => {
       report(<Assert key="write data async test" expect={'123456789011121314'} actual={d1}/>)
       return base64Test()
     })
   })
-  .catch(err => {
-    report(<Assert key="Error" expect={null} actual={err}/>)
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
     done()
   })
 
@@ -215,15 +267,18 @@ describe('write stream API test', (report, done) => {
       stream.onData((chunk) => {
         d2 += chunk
       })
-      stream.onError((detail) => {
+      stream.onError((err) => {
         // Outside the promise
-        throw new Error(detail)
+        report(<Assert key="Error" expect={null} actual={err}/>)
       })
       stream.onEnd(() => {
-        report(<Assert key="file should be overwritten by base64 encoded data"
-                       expect={RNFetchBlob.base64.encode(expect)} actual={d2}/>)
+        report(<Assert key="file should be overwritten by base64 encoded data" expect={RNFetchBlob.base64.encode(expect)} actual={d2}/>)
         done()
       })
+    })
+    .catch((err) => {
+      report(<Assert key="should not have failed" expect={null} actual={err}/>)
+      done()
     })
   }
 })
@@ -232,39 +287,55 @@ describe('mv API test', {timeout: 10000}, (report, done) => {
   let p = dirs.DocumentDir + '/mvTest' + Date.now()
   let dest = p + '-dest-' + Date.now()
   let content = Date.now() + '-test'
+
   fs.createFile(p, content, 'utf8')
   .then(() => fs.mkdir(dest))
   .then(() => fs.mv(p, dest + '/moved'))
   .then(() => fs.exists(p))
   .then((exist) => {
     report(<Assert key="file should not exist in old path" expect={false} actual={exist}/>)
-    return fs.exists(dest + '/moved')
   })
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
+  .then(() => fs.exists(dest + '/moved'))
   .then((exist) => {
     report(<Assert key="file should be moved to destination" expect={true} actual={exist}/>)
-    return fs.ls(dest)
   })
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
+  .then(() => fs.ls(dest))
   .then((files) => {
     report(<Assert key="file name should be correct" expect={'moved'} actual={files[0]}/>)
-    return fs.readStream(dest + '/moved')
   })
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
+  .then(() => fs.readStream(dest + '/moved'))
   .then((stream) => {
     let actual = ''
     stream.open()
     stream.onData((chunk) => {
       actual += chunk
     })
-    stream.onError((detail) => {
+    stream.onError((err) => {
       // Outside the promise
-      throw new Error(detail)
+      report(<Assert key="Error" expect={null} actual={err}/>)
     })
     stream.onEnd(() => {
       report(<Assert key="file content should be correct" expect={content} actual={actual}/>)
       done()
     })
   })
-  .catch(err => {
-    report(<Assert key="Error" expect={null} actual={err}/>)
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
     done()
   })
 })
@@ -273,35 +344,46 @@ describe('cp API test', {timeout: 10000}, (report, done) => {
   let p = dirs.DocumentDir + '/cpTest' + Date.now()
   let dest = p + '-dest-' + Date.now()
   let content = Date.now() + '-test'
+
   fs.createFile(p, content, 'utf8')
   .then(() => fs.mkdir(dest))
   .then(() => fs.cp(p, dest + '/cp'))
   .then(() => fs.exists(dest + '/cp'))
   .then((exist) => {
     report(<Assert key="file should be copy to destination" expect={true} actual={exist}/>)
-    return fs.ls(dest)
   })
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
+  .then(() => fs.ls(dest))
   .then((files) => {
     report(<Assert key="file name should be correct" expect={'cp'} actual={files[0]}/>)
-    return fs.readStream(dest + '/cp')
   })
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
+  .then(() => fs.readStream(dest + '/cp'))
   .then((stream) => {
     let actual = ''
     stream.open()
     stream.onData((chunk) => {
       actual += chunk
     })
-    stream.onError((detail) => {
+    stream.onError((err) => {
       // Outside the promise
-      throw new Error(detail)
+      report(<Assert key="Error" expect={null} actual={err}/>)
     })
     stream.onEnd(() => {
       report(<Assert key="file content should be correct" expect={content} actual={actual}/>)
       done()
     })
   })
-  .catch(err => {
-    report(<Assert key="Error" expect={null} actual={err}/>)
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
     done()
   })
 })
@@ -310,15 +392,21 @@ describe('ASCII data test', (report, done) => {
   let p = dirs.DocumentDir + '/ASCII-test-' + Date.now()
   let expect = 'fetch-blob-' + Date.now()
 
-  fs.createFile(p, 'utf8')
+  fs.createFile(p, '', 'utf8')
   .then(() => fs.writeStream(p, 'ascii', false))
-  .then((ofstream) => {
+  .then((stream) => {
+    const promises = []
     for (let i = 0; i < expect.length; i++) {
-      ofstream.write([expect[i].charCodeAt(0)])
+      promises.push(stream.write([expect[i].charCodeAt(0)]))
     }
-    ofstream.write(['g'.charCodeAt(0), 'g'.charCodeAt(0)])
-    return ofstream.close()
+    promises.push(stream.write(['g'.charCodeAt(0), 'g'.charCodeAt(0)]))
+    return Promise.all(promises).then(() => stream.close())
   })
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
   .then(() => fs.readStream(p, 'ascii'))
   .then((stream) => {
     let res = []
@@ -326,30 +414,28 @@ describe('ASCII data test', (report, done) => {
     stream.onData((chunk) => {
       res = res.concat(chunk)
     })
-    stream.onError((detail) => {
+    stream.onError((err) => {
       // Outside the promise
-      throw new Error(detail)
+      report(<Assert key="Error" expect={null} actual={err}/>)
     })
     stream.onEnd(() => {
       res = res.map((byte) => String.fromCharCode(byte)).join('')
-      report(
-        <Assert key="data written in ASCII format should correct" expect={expect + 'gg'} actual={res}/>)
+      report(<Assert key="data written in ASCII format should correct" expect={expect + 'gg'} actual={res}/>)
       done()
     })
   })
-  .catch(err => {
-    report(<Assert key="Error" expect={null} actual={err}/>)
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
     done()
   })
 })
 
 describe('ASCII file test', (report, done) => {
   let p = dirs.DocumentDir + '/'
-  let filename = ''
-  let expect = []
+  let filename = 'ASCII-file-test' + Date.now() + '.txt'
+  let expect = 'ascii test ' + Date.now()
   let base64 = RNFetchBlob.base64
-  filename = 'ASCII-file-test' + Date.now() + '.txt'
-  expect = 'ascii test ' + Date.now()
+
   fs.createFile(p + filename, getASCIIArray(expect), 'ascii')
   .then(() => fs.readStream(p + filename, 'base64'))
   .then((stream) => {
@@ -358,23 +444,24 @@ describe('ASCII file test', (report, done) => {
     stream.onData((chunk) => {
       actual += chunk
     })
-    stream.onError((detail) => {
+    stream.onError((err) => {
       // Outside the promise
-      throw new Error(detail)
+      report(<Assert key="Error" expect={null} actual={err}/>)
     })
     stream.onEnd(() => {
       report(<Assert key="written data verify" expect={expect} actual={base64.decode(actual)}/>)
       done()
     })
   })
-  .catch(err => {
-    report(<Assert key="Error" expect={null} actual={err}/>)
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
     done()
   })
 })
 
 describe('format conversion', (report, done) => {
   let p = dirs.DocumentDir + '/foo-' + Date.now()
+
   fs.createFile(p, [102, 111, 111], 'ascii')
   .then(() => fs.readStream(p, 'utf8'))
   .then((stream) => {
@@ -383,53 +470,52 @@ describe('format conversion', (report, done) => {
     stream.onData((chunk) => {
       res += chunk
     })
-    stream.onError((detail) => {
+    stream.onError((err) => {
       // Outside the promise
-      throw new Error(detail)
+      report(<Assert key="Error" expect={null} actual={err}/>)
     })
     stream.onEnd(() => {
       report(<Assert key="write utf8 and read by ascii" expect="foo" actual={res}/>)
       done()
     })
   })
-  .catch(err => {
-    report(<Assert key="Error" expect={null} actual={err}/>)
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
     done()
   })
 })
 
 describe('stat and lstat test', (report, done) => {
-  let p = dirs.DocumentDir + '/' + 'ls-stat-test' + Date.now()
   let file = null
+  const expect = ['size', 'type', 'lastModified', 'filename', 'path']
 
   fs.lstat(dirs.DocumentDir)  // stat a folder
   .then((stat) => {
     report(<Assert key="result should be an array" expect={true} actual={Array.isArray(stat)}/>)
     file = stat[0].path
-    return fs.stat(file)  // stat a file
-  })
-  .then((stat) => {
-    report(<Assert key="should have properties" expect={['size', 'type', 'lastModified', 'filename', 'path']}
-                   comparer={Comparer.hasProperties} actual={stat}/>)
-    return fs.stat('13123132')
-  })
-  .then(() => {
-    // TODO ???
   })
   .catch((err) => {
-    console.log(err)
-    report(<Assert key="stat error catacable" expect={true} actual={true}/>)
-    done()
-  })
-  .then(() => {
-    // TODO ???
-  })
-  .catch((err) => {
-    console.log(err)
-    report(<Assert key="lstat error catacable" expect={true} actual={true}/>)
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
     done()
   })
 
+  .then(() => fs.stat(file))  // stat a file
+  .then((stat) => {
+    report(<Assert key="should have properties" expect={expect} comparer={Comparer.hasProperties} actual={stat}/>)
+  })
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
+  .then(() => fs.stat('13123132'))
+  .then((list) => {
+    report(<Assert key="should have failed" expect={false} actual={true}/>)
+  })
+  .catch((err) => {
+    report(<Assert key="stat of non-existent file should fail" expect={true} actual={true}/>)
+    done()
+  })
 })
 
 describe('fs.slice test', (report, done) => {
@@ -448,8 +534,8 @@ describe('fs.slice test', (report, done) => {
   .then((res) => res.rawResp())
   .then((res) => {
     source = res.path()
-    return fs.stat(source)
   })
+  .then(() => fs.stat(source))
   // separate file into 4kb chunks
   .then((stat) => {
     size = stat.size
@@ -482,8 +568,9 @@ describe('fs.slice test', (report, done) => {
         })
       }.bind(this, dests[d]))
     }
-    return p.then(() => fs.stat(combined))
+    return p
   })
+  .then(() => fs.stat(combined))
   .then((stat) => {
     report(
       <Assert key="verify file size" expect={size} actual={stat.size}/>,
@@ -493,8 +580,8 @@ describe('fs.slice test', (report, done) => {
     )
     done()
   })
-  .catch(err => {
-    report(<Assert key="Error" expect={null} actual={err}/>)
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
     done()
   })
 })
@@ -509,48 +596,81 @@ describe('hash API test', (report, done) => {
     binFile = res.path()
   })
   .then(() => fs.createFile(txtFile, 'What is SHA-256? The SHA (Secure Hash Algorithm) is one of a number of cryptographic hash functions.', 'utf8'))
+  .catch((err) => {
+    report(<Assert key="test setup should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
   .then(() => fs.hash(txtFile, 'md5'))
   .then((hash) => {
     report(<Assert key="MD5 hash of text file should be created" expect={'3fce512da59b4abda4c5f37ef7859443'} actual={hash}/>)
   })
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
   .then(() => fs.hash(txtFile, 'sha256'))
   .then((hash) => {
     report(<Assert key="SHA-256 hash of text file should be created" expect={'92fc68e5477e96c2beac69237bb8449350a358bd5a6fe578d1b374814b1f4486'} actual={hash}/>)
   })
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
   .then(() => fs.hash(binFile, 'md5'))
   .then((hash) => {
     report(<Assert key="MD5 hash of binary file should be created" expect={'c7e6697f842252de45eb70eb6314987a'} actual={hash}/>)
   })
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
+    done()
+  })
+
   .then(() => fs.hash(binFile, 'sha256'))
   .then((hash) => {
     report(<Assert key="SHA-256 hash of binary file should be created" expect={'ffb5be2160cc5d594378a71e187ccfe06b0829877721e285669c01467c175ca7'} actual={hash}/>)
   })
+
   .then(() => invalidFilenameCheck())
+
+  .then(() => dirInsteadOfFileCheck())
+
   .then(() => invalidAlgorithmCheck())
+
   .then(() => done())
-  .catch(err => {
-    report(<Assert key="Error" expect={null} actual={err}/>)
+  .catch((err) => {
+    report(<Assert key="should not have failed" expect={null} actual={err}/>)
     done()
   })
 
   function invalidFilenameCheck () {
     return fs.hash('INVALID_FILE', 'sha256')
-    .then(() => report(<Assert key="should have reported 'file not found'" expect={true} actual={false}/>))
+    .then(() => report(<Assert key="should have reported 'file not found'" expect={false} actual={true}/>))
     .catch((err) => {
       report(<Assert key="Non-existing file should cause error" expect={'ENOENT'} actual={err.code}/>)
     })
   }
 
+  function dirInsteadOfFileCheck () {
+    return fs.hash(dirs.DocumentDir, 'sha256')
+    .then(() => report(<Assert key="should have reported 'is a directory'" expect={false} actual={true}/>))
+    .catch((err) => {
+      report(<Assert key="Directory instead of file should cause error" expect={'EISDIR'} actual={err.code}/>)
+    })
+  }
+
   function invalidAlgorithmCheck () {
     return fs.hash(binFile, 'INVALID')
-    .then(() => report(<Assert key="should have reported 'invalid algorithm'" expect={true} actual={false}/>))
+    .then(() => report(<Assert key="should have reported 'invalid algorithm'" expect={false} actual={true}/>))
     .catch((err) => {
       report(<Assert key="Invalid hash algorithm should cause error" expect={'EINVAL'} actual={err.code}/>)
     })
   }
 })
 
-describe('binary data to ascii file size checking', (report, done) => {
+false && describe('binary data to ascii file size checking', (report, done) => {
   let file = null
   let expectedSize = 0
 

--- a/test/test-init.js
+++ b/test/test-init.js
@@ -19,11 +19,16 @@ const { Assert, Comparer, Info, prop } = RNTest
 // test environment variables
 
 prop('FILENAME', `${Platform.OS}-0.10.0-${Date.now()}.png`)
-prop('TEST_SERVER_URL', 'http://localhost:8123')
-prop('TEST_SERVER_URL_SSL', 'https://localhost:8124')
-// prop('TEST_SERVER_URL', 'http://192.168.1.6:8123')
-// prop('TEST_SERVER_URL_SSL', 'https://192.168.1.6:8124')
-prop('DROPBOX_TOKEN', 'fsXcpmKPrHgAAAAAAAAAoXZhcXYWdgLpQMan6Tb_bzJ237DXhgQSev12hA-gUXt4')
+
+// prop('TEST_SERVER_URL', 'http://localhost:8123')
+// prop('TEST_SERVER_URL_SSL', 'https://localhost:8124')
+
+// When running in the Android emulator 10.0.2.2 is the IP to reach 127.0.0.1 of the host running the emulator
+// https://developer.android.com/studio/run/emulator-networking.html
+prop('TEST_SERVER_URL', 'http://10.0.2.2:8123')
+prop('TEST_SERVER_URL_SSL', 'https://10.0.2.2:8124')
+
+prop('DROPBOX_TOKEN', 'YOUR TOKEN HERE')
 prop('styles', {
   image : {
     width: Dimensions.get('window').width*0.9,
@@ -103,8 +108,8 @@ describe('GET image from server', (report, done) => {
 require('./test-0.10.7')
 // require('./test-background.js')
 // require('./test-stream')
-// require('./test-fetch')
-// require('./test-fs')
+require('./test-fetch')
+require('./test-fs')
 // require('./test-xmlhttp')
 // require('./test-blob')
 // require('./test-firebase')


### PR DESCRIPTION
This update is for the PR I'm going to submit [from my RNFB-0.10.9 branch](https://github.com/lll000111/react-native-fetch-blob/tree/0.10.9) - it now has been tested.

**I can (and therefore did) only test on Android (emulator)**

I concentrated my updates on `test-fs.js` because almost all my PR will be focused on the fs methods. More work needs to be done, I did not add error codes to all methods yet, I just wanted to have a working basis for a start but following the same pattern will be easy now.
